### PR TITLE
Allow frontend control of uids

### DIFF
--- a/backend/src/posts.js
+++ b/backend/src/posts.js
@@ -121,14 +121,13 @@ function selectPost(req, res, next) {
 function createPost(req, res, next) {
     /**
      * @param:
-     *  pid string (required),
      *  uid string (required),
      *  imgLink string (optional),
      *  datetime string (optional),
-     *  coordinate (float,float) (optional),
-     *  animalName string,
-     *  quantity int,
-     *  activity string
+     *  coordinate (float,float) (required),
+     *  animalName string (optional),
+     *  quantity int (optional),
+     *  activity string (optional)
      * @returns:
      *  message string
      *      "post created"
@@ -179,9 +178,9 @@ function updatePostByPID(req, res, next) {
      *  imgLink string (optional),
      *  datetime string (optional),
      *  coordinate (float,float) (optional),
-     *  animalName string,
-     *  quantity int,
-     *  activity string
+     *  animalName string (optional),
+     *  quantity int (optional),
+     *  activity string (optional)
      * @returns:
      *  message string
      *      `post with pid ${pid} updated`

--- a/backend/src/users.js
+++ b/backend/src/users.js
@@ -78,6 +78,7 @@ function selectUser(req, res, next) {
 function createUser(req, res, next) {
     /**
      * @param:
+     *  uid string (optional)
      *  email string (optional)
      *  username string (optional)
      *  bio string (optional)
@@ -93,8 +94,7 @@ function createUser(req, res, next) {
      *      error message
      *  uid string (on success)
      */
-    //NO UID (randomly generated)
-    const columns = ["email", "username", "bio", "pfpLink", "superUser", "locationPerm", "notificationPerm", "colorBlindRating"]
+    const columns = ["uid", "email", "username", "bio", "pfpLink", "superUser", "locationPerm", "notificationPerm", "colorBlindRating"]
     var dict = {}
     for(const col of columns) {
         if(req.body[col]) {
@@ -102,8 +102,9 @@ function createUser(req, res, next) {
         }
     }
 
-    const uid = randomstring.generate(16)
-    dict['uid'] = uid
+    if(dict['uid'] === undefined) {
+        dict['uid'] = randomstring.generate(16)
+    }
 
     const fields = Object.keys(dict).join(', ')
     const placeholders = Object.keys(dict).map((_, i) => `$${i + 1}`).join(', ')
@@ -121,7 +122,7 @@ function createUser(req, res, next) {
         }
         return res.status(200).json({
             message: "user created",
-            uid: uid
+            uid: dict['uid']
         })
     })
 }

--- a/backend/test/posts.test.js
+++ b/backend/test/posts.test.js
@@ -55,6 +55,28 @@ describe("selecting posts", () => {
             .get('/posts/selectPost')
             .send(`uid=${uid}`) //send body parameters
             .send('coordinate=(0.0, 0.0)')
+            .send('animalName=bear')
+            assert.strictEqual(resp.status, 200)
+            assert.deepStrictEqual(resp.body.message, [])
+        })
+        it("POST: test select with few constraints", async () => {
+            await teardown()
+            
+            const create_user = await request(app)
+            .post('/users/createUser')
+            const uid = create_user.body.uid
+
+            const create_post = await request(app)
+            .post('/posts/createPost')
+            .send(`uid=${uid}`)
+            .send('coordinate=(0.0, 0.0)')
+            assert.strictEqual(create_post.body.message, "post created")
+            const pid = create_post.body.pid
+
+            const resp = await request(app)
+            .get('/posts/selectPost')
+            .send(`uid=${uid}`) //send body parameters
+            .send('coordinate=(0.0, 0.0)')
             assert.strictEqual(resp.status, 200)
             assert.deepStrictEqual(resp.body.message, [
                 {

--- a/backend/test/users.test.js
+++ b/backend/test/users.test.js
@@ -46,7 +46,7 @@ describe("selecting users", () => {
         assert.strictEqual(resp2.status,200)
         assert.deepStrictEqual(resp2.body.message, [])
     })
-    it("USER: test select with many constraints", async () => {
+    it("USER: test select with few constraints", async () => {
         await teardown()
         const resp1 = await request(app)
         .post('/users/createUser')
@@ -73,29 +73,43 @@ describe("selecting users", () => {
             }
         ])
     })
-    it("USER: test select with few constraints", async () => {
+    it("USER: test select with ALL constraints", async () => {
         await teardown()
         const resp1 = await request(app)
         .post('/users/createUser')
         .send('email=jj@umass')
+        .send('username=John')
+        .send('bio=Student')
+        .send('pfpLink=test_link')
+        .send('superUser=1')
+        .send('locationPerm=1')
+        .send('notificationPerm=1')
+        .send('colorBlindRating=10')
         const uid = resp1.body.uid
 
         const resp2 = await request(app)
         .get('/users/selectUser')
         .send(`uid=${uid}`) //send body parameters
         .send('email=jj@umass') //send body parameters
+        .send('username=John')
+        .send('bio=Student')
+        .send('pfpLink=test_link')
+        .send('superUser=1')
+        .send('locationPerm=1')
+        .send('notificationPerm=1')
+        .send('colorBlindRating=10')
         assert.strictEqual(resp2.status,200)
         assert.deepStrictEqual(resp2.body.message, [
             {
                 "uid": uid,
                 "email": "jj@umass",
-                "username": null,
-                "bio": null,
-                "pfplink": null,
-                "superuser": null,
-                "locationperm": null,
-                "notificationperm": null,
-                "colorblindrating": null
+                "username": "John",
+                "bio": "Student",
+                "pfplink": "test_link",
+                "superuser": true,
+                "locationperm": true,
+                "notificationperm": true,
+                "colorblindrating": 10
             }
         ])
     })
@@ -110,6 +124,10 @@ describe("selecting users", () => {
         .post('/users/createUser')
         .send('email=jj@umass')
         const uid2 = resp1b.body.uid
+
+        const resp1c = await request(app)
+        .post('/users/createUser')
+        .send('email=aj@umass')
 
         const resp2 = await request(app)
         .get('/users/selectUser')

--- a/backend/test/users.test.js
+++ b/backend/test/users.test.js
@@ -77,6 +77,7 @@ describe("selecting users", () => {
         await teardown()
         const resp1 = await request(app)
         .post('/users/createUser')
+        .send('uid=345')
         .send('email=jj@umass')
         .send('username=John')
         .send('bio=Student')
@@ -85,11 +86,10 @@ describe("selecting users", () => {
         .send('locationPerm=1')
         .send('notificationPerm=1')
         .send('colorBlindRating=10')
-        const uid = resp1.body.uid
 
         const resp2 = await request(app)
         .get('/users/selectUser')
-        .send(`uid=${uid}`) //send body parameters
+        .send(`uid=345`) //send body parameters
         .send('email=jj@umass') //send body parameters
         .send('username=John')
         .send('bio=Student')
@@ -101,7 +101,7 @@ describe("selecting users", () => {
         assert.strictEqual(resp2.status,200)
         assert.deepStrictEqual(resp2.body.message, [
             {
-                "uid": uid,
+                "uid": "345",
                 "email": "jj@umass",
                 "username": "John",
                 "bio": "Student",
@@ -171,6 +171,7 @@ describe("creating users", () => {
    it("USER: test create with all params", async () => {
         await teardown()
         testInput = {
+            uid: '345',
             email: 'jj@umass.edu',
             username: 'jamesbarr',
             bio: 'bio',
@@ -182,6 +183,7 @@ describe("creating users", () => {
         }
         const resp = await request(app)
         .post('/users/createUser')
+        .send(`uid=${testInput.uid}`)
         .send(`email=${testInput.email}`)
         .send(`username=${testInput.username}`)
         .send(`bio=${testInput.bio}`)

--- a/genTables.sql
+++ b/genTables.sql
@@ -2,25 +2,25 @@ CREATE EXTENSION IF NOT EXISTS cube;
 
 CREATE EXTENSION IF NOT EXISTS earthdistance;
 
-CREATE TABLE Users (
-    uid CHAR(16) PRIMARY KEY, 
-    email VARCHAR(50),
-    username VARCHAR(50),
-    bio VARCHAR(50),
-    pfpLink VARCHAR(5000),
+CREATE TABLE users (
+    uid VARCHAR(128) PRIMARY KEY, 
+    email TEXT,
+    username TEXT,
+    bio TEXT,
+    pfpLink TEXT,
     superUser BOOLEAN,
     locationPerm BOOLEAN,
     notificationPerm BOOLEAN,
     colorBlindRating INTEGER
 );
 
-CREATE TABLE POSTS (
+CREATE TABLE posts (
     pid CHAR(16) PRIMARY KEY,
-    uid CHAR(16) NOT NULL REFERENCES Users(uid) ON DELETE CASCADE,
-    imgLink VARCHAR(5000),
+    uid VARCHAR(128) NOT NULL REFERENCES users(uid) ON DELETE CASCADE,
+    imgLink TEXT,
     datetime TIMESTAMP,
     coordinate POINT NOT NULL,
-    animalName VARCHAR(50),
+    animalName TEXT,
     quantity INTEGER,
-    activity VARCHAR(50)
+    activity TEXT
 );


### PR DESCRIPTION
`createUser` now takes an optional `uid` argument. If no such argument is provided, the uid will be randomly generated as before, so this change won't break anything.
I also updated the tests (some of them were inaccurately named, and two of the users tests were identical), and updated the types in the database, allowing longer uids and changing most of the VARCHAR(n) types to TEXT.